### PR TITLE
Fix hardcoded source quality labels to display actual track metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,8 +33,8 @@
           <div class="track-title" id="trackTitle">Loading title...</div>
           <div class="track-album" id="trackAlbum">Album info...</div>
           <div class="track-meta">
-            <span>Lossless quality: 16-bit FLAC</span><br>
-            <span>Sample rate: 44.1 kHz</span><br>
+            <span id="sourceQuality">Lossless quality: Loading...</span><br>
+            <span id="sampleRate">Sample rate: Loading...</span><br>
             <span id="audioQualityText">Current audio quality</span>
           </div>
         </div>

--- a/public/script.js
+++ b/public/script.js
@@ -12,6 +12,8 @@ const trackTitle = document.getElementById('trackTitle');
 const trackArtist = document.getElementById('trackArtist');
 const trackAlbum = document.getElementById('trackAlbum');
 const audioQualityText = document.getElementById('audioQualityText');
+const sourceQuality = document.getElementById('sourceQuality');
+const sampleRate = document.getElementById('sampleRate');
 const yearBadge = document.getElementById('yearBadge');
 const recentlyPlayed = document.getElementById('recentlyPlayed');
 const albumArt = document.getElementById('albumArt');
@@ -200,6 +202,8 @@ async function updateMetadata() {
     // Update audio quality
     if (data.bit_depth && data.sample_rate) {
       const sampleRateKHz = (data.sample_rate / 1000).toFixed(1);
+      sourceQuality.textContent = `Lossless quality: ${data.bit_depth}-bit FLAC`;
+      sampleRate.textContent = `Sample rate: ${sampleRateKHz} kHz`;
       audioQualityText.textContent = `Playing at ${data.bit_depth}-bit / ${sampleRateKHz}kHz`;
     }
 


### PR DESCRIPTION
Fixes #3

This PR addresses the issue where source quality information was hardcoded in the HTML.

## Changes
- Replaced hardcoded "16-bit FLAC" and "44.1 kHz" text with dynamic elements
- Updated JavaScript to populate source quality from the metadata API
- Now displays actual bit_depth and sample_rate from each track's metadata

## Testing
The quality labels will now update automatically when metadata is fetched every 10 seconds, reflecting the actual audio quality of the current track.

----
Generated with [Claude Code](https://claude.ai/code)